### PR TITLE
Improve API key modal interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,18 @@
             <p class="text-lg text-[#118AB2] mt-2">Visual Itinerary & Cost Analysis for Mr. Poon & Group</p>
         </header>
 
+        <div id="api-key-alert" class="hidden bg-yellow-50 border-l-4 border-[#FFD166] p-4 rounded-lg mb-12 md:flex md:items-center md:justify-between gap-4">
+            <div>
+                <h2 class="text-lg font-semibold text-[#073B4C]">Configure Google Gemini API Access</h2>
+                <p id="api-key-status" class="text-sm text-gray-700 mt-1"></p>
+                <p class="text-xs text-gray-500 mt-2">Your API key is stored in this browser only and never sent to our servers.</p>
+            </div>
+            <div class="flex flex-col sm:flex-row gap-2 mt-4 md:mt-0">
+                <button id="configure-api-key-btn" class="bg-[#118AB2] text-white font-semibold py-2 px-4 rounded-lg hover:bg-[#073B4C] transition-colors">Add or Update Key</button>
+                <button id="remove-api-key-btn" class="hidden border border-[#FF6B6B] text-[#FF6B6B] font-semibold py-2 px-4 rounded-lg hover:bg-[#FF6B6B] hover:text-white transition-colors">Remove Key</button>
+            </div>
+        </div>
+
         <section class="grid grid-cols-1 md:grid-cols-3 gap-8 mb-12 text-center">
             <div class="bg-white rounded-lg shadow-md p-6">
                 <p class="text-5xl font-bold text-[#FF6B6B]">13</p>
@@ -215,6 +227,27 @@
                  <div id="modal-loader" class="hidden justify-center my-6">
                     <div class="loader"></div>
                 </div>
+            </div>
+        </div>
+    </div>
+
+    <div id="api-key-modal" class="modal fixed inset-0 bg-black bg-opacity-50 z-50 hidden items-center justify-center p-4">
+        <div class="bg-white rounded-lg shadow-xl w-full max-w-lg flex flex-col">
+            <div class="flex justify-between items-center p-4 border-b">
+                <h3 class="text-xl font-bold">Google Gemini API Key</h3>
+                <button id="api-key-modal-close" class="text-2xl font-bold">&times;</button>
+            </div>
+            <div class="p-6 space-y-4">
+                <div>
+                    <label for="api-key-input" class="block text-sm font-medium text-gray-700">API Key</label>
+                    <input id="api-key-input" type="password" autocomplete="off" class="mt-1 w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#118AB2] focus:outline-none" placeholder="AIza...">
+                    <p id="api-key-input-error" class="hidden text-sm text-red-600 mt-2">Please enter a valid API key before saving.</p>
+                </div>
+                <p class="text-sm text-gray-600">The key is saved to your browser's local storage and used only to call Google's Gemini API directly from this page.</p>
+            </div>
+            <div class="flex justify-end gap-2 px-6 py-4 border-t">
+                <button id="cancel-api-key-btn" class="border border-gray-300 text-gray-700 font-semibold py-2 px-4 rounded-lg hover:bg-gray-100 transition-colors">Cancel</button>
+                <button id="save-api-key-btn" class="bg-[#118AB2] text-white font-semibold py-2 px-4 rounded-lg hover:bg-[#073B4C] transition-colors">Save Key</button>
             </div>
         </div>
     </div>
@@ -387,8 +420,78 @@
         }
     });
 
-    const apiKey = "";
-    const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-05-20:generateContent?key=${apiKey}`;
+    const buildApiUrl = (key) => `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-05-20:generateContent?key=${encodeURIComponent(key)}`;
+    const getStoredApiKey = () => {
+        try {
+            return localStorage.getItem('geminiApiKey') || '';
+        } catch (storageError) {
+            console.warn('Unable to access localStorage:', storageError);
+            return '';
+        }
+    };
+
+    let apiKey = getStoredApiKey();
+    let apiUrl = apiKey ? buildApiUrl(apiKey) : '';
+    const apiKeyUiState = {
+        status: apiKey ? 'configured' : 'missing',
+        detail: ''
+    };
+
+    const setApiKey = (newKey) => {
+        apiKey = newKey;
+        apiUrl = apiKey ? buildApiUrl(apiKey) : '';
+        apiKeyUiState.status = apiKey ? 'configured' : 'missing';
+        apiKeyUiState.detail = '';
+        try {
+            if (apiKey) {
+                localStorage.setItem('geminiApiKey', apiKey);
+            } else {
+                localStorage.removeItem('geminiApiKey');
+            }
+        } catch (storageError) {
+            console.warn('Unable to persist Gemini API key:', storageError);
+        }
+        updateApiKeyUi();
+    };
+
+    const updateApiKeyUi = () => {
+        const alert = document.getElementById('api-key-alert');
+        const status = document.getElementById('api-key-status');
+        const removeBtn = document.getElementById('remove-api-key-btn');
+
+        if (!alert || !status || !removeBtn) {
+            return;
+        }
+
+        alert.classList.remove('hidden');
+        alert.classList.remove('bg-yellow-50', 'border-[#FFD166]', 'bg-green-50', 'border-[#06D6A0]', 'bg-red-50', 'border-[#FF6B6B]');
+
+        if (apiKeyUiState.status === 'missing') {
+            alert.classList.add('bg-yellow-50', 'border-[#FFD166]');
+            status.textContent = 'AI-powered suggestions are currently unavailable because no Google Gemini API key has been configured. Please add your API key to enable this feature.';
+            removeBtn.classList.add('hidden');
+            return;
+        }
+
+        if (apiKeyUiState.status === 'unauthorized') {
+            alert.classList.add('bg-red-50', 'border-[#FF6B6B]');
+            const detailText = apiKeyUiState.detail ? ` Details from Google: ${apiKeyUiState.detail}` : '';
+            status.textContent = `We couldn't authenticate with Google using the stored Gemini API key. Please verify the key is correct, enabled for the Generative Language API, and allowed to call this model.${detailText}`;
+            removeBtn.classList.remove('hidden');
+            return;
+        }
+
+        alert.classList.add('bg-green-50', 'border-[#06D6A0]');
+        status.textContent = 'A Google Gemini API key is stored locally in this browser. You can update or remove it at any time.';
+        removeBtn.classList.remove('hidden');
+    };
+
+    const markApiKeyUnauthorized = (detail = '') => {
+        const sanitizedDetail = typeof detail === 'string' ? detail.trim() : '';
+        apiKeyUiState.status = 'unauthorized';
+        apiKeyUiState.detail = sanitizedDetail;
+        updateApiKeyUi();
+    };
 
     const itineraryData = {
         '1': 'Arrival in Dubai. Transfer to hotel.',
@@ -400,7 +503,83 @@
         '8': 'A unique "Hidden Dubai" tour including monorail tickets before a direct airport transfer.'
     };
 
+    const buildAuthErrorMessage = (detail = '') => {
+        const baseMessage = "The AI service rejected the request. Please verify that your Google Gemini API key is valid, enabled for the Generative Language API, and allowed to call this model.";
+        if (!detail) return baseMessage;
+        const trimmedDetail = detail.trim();
+        return trimmedDetail ? `${baseMessage} Details from Google: ${trimmedDetail}` : baseMessage;
+    };
+
+    const summarizeDetail = (text, maxLength = 200) => {
+        if (typeof text !== 'string') {
+            return '';
+        }
+        const normalized = text.replace(/\s+/g, ' ').trim();
+        if (!normalized) {
+            return '';
+        }
+        if (normalized.length <= maxLength) {
+            return normalized;
+        }
+        return `${normalized.slice(0, maxLength - 1).trim()}…`;
+    };
+
+    const extractErrorDetail = (rawBody, parsedBody, contentType = '') => {
+        const apiMessage = parsedBody?.error?.message;
+        if (typeof apiMessage === 'string' && apiMessage.trim()) {
+            return summarizeDetail(apiMessage);
+        }
+
+        if (typeof rawBody !== 'string') {
+            return '';
+        }
+
+        const trimmedBody = rawBody.trim();
+        if (!trimmedBody) {
+            return '';
+        }
+
+        if (contentType.includes('text/html') || /^</.test(trimmedBody)) {
+            try {
+                const parser = new DOMParser();
+                const doc = parser.parseFromString(trimmedBody, 'text/html');
+                const text = doc.body?.textContent;
+                const summarized = summarizeDetail(text || '');
+                if (summarized) {
+                    return summarized;
+                }
+            } catch (parseErr) {
+                console.warn('Unable to parse Gemini HTML error payload:', parseErr);
+            }
+        }
+
+        return summarizeDetail(trimmedBody);
+    };
+
+    const renderGeminiResponse = (element, text) => {
+        if (!element) return;
+
+        const safeText = typeof text === 'string' ? text : '';
+        const trimmed = safeText.trim();
+
+        if (!trimmed) {
+            element.textContent = 'The AI response was empty.';
+            return;
+        }
+
+        const looksLikeHtml = /^<!?doctype\s+html/i.test(trimmed) || /^<\w+(\s|>)/i.test(trimmed);
+        if (looksLikeHtml) {
+            element.textContent = trimmed;
+            return;
+        }
+
+        element.innerHTML = marked.parse(trimmed);
+    };
+
     async function callGemini(prompt, retries = 3, delay = 1000) {
+        if (!apiKey || !apiKey.trim()) {
+            return "AI-powered suggestions are currently unavailable because no Google Gemini API key has been configured. Please add your API key to enable this feature.";
+        }
         try {
             const payload = {
                 contents: [{ parts: [{ text: prompt }] }],
@@ -410,16 +589,36 @@
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(payload)
             });
+            const rawBody = await response.text();
+            let parsedBody = null;
+            if (rawBody) {
+                try {
+                    parsedBody = JSON.parse(rawBody);
+                } catch (parseError) {
+                    console.warn('Unable to parse Gemini error payload as JSON:', parseError);
+                }
+            }
 
             if (!response.ok) {
-                 if (response.status === 429 && retries > 0) {
+                if (response.status === 429 && retries > 0) {
                     await new Promise(res => setTimeout(res, delay));
                     return callGemini(prompt, retries - 1, delay * 2);
                 }
-                throw new Error(`API call failed with status: ${response.status}`);
+                const contentType = response.headers.get('content-type') || '';
+                const apiMessage = extractErrorDetail(rawBody, parsedBody, contentType);
+                if ([401, 403].includes(Number(response.status))) {
+                    markApiKeyUnauthorized(apiMessage);
+                    return buildAuthErrorMessage(apiMessage);
+                }
+                const genericDetail = apiMessage ? ` Details from Google: ${apiMessage}` : '';
+                return `The AI service returned an unexpected ${response.status} response.${genericDetail}`;
             }
 
-            const result = await response.json();
+            if (!parsedBody) {
+                return "Sorry, I couldn't read the AI response because it was returned in an unexpected format. Please try again in a moment.";
+            }
+
+            const result = parsedBody;
             const candidate = result.candidates?.[0];
             if (candidate && candidate.content?.parts?.[0]?.text) {
                 return candidate.content.parts[0].text;
@@ -428,7 +627,22 @@
             }
         } catch (error) {
             console.error(error);
-            return `An error occurred while fetching suggestions: ${error.message}. Please try again later.`;
+            const errorMessage = typeof error?.message === 'string' ? error.message : '';
+            if (typeof error?.status !== 'undefined' && [401, 403].includes(Number(error.status))) {
+                markApiKeyUnauthorized();
+                return buildAuthErrorMessage();
+            }
+            if (errorMessage) {
+                const normalizedMessage = errorMessage.toLowerCase();
+                if (normalizedMessage.includes('status: 401') || normalizedMessage.includes('status: 403')) {
+                    markApiKeyUnauthorized();
+                    return buildAuthErrorMessage();
+                }
+            }
+            if (errorMessage && errorMessage.toLowerCase().includes('failed to fetch')) {
+                return "I couldn't reach the AI service. Please check your internet connection and try again in a moment.";
+            }
+            return "An unexpected error occurred while contacting the AI service. Please try again later.";
         }
     }
 
@@ -452,7 +666,7 @@
         const prompt = `You are a luxury travel concierge in Dubai. A group of 13 guests is looking for suggestions for their free day. They are interested in "${query}". Provide 3-4 detailed and high-end suggestions suitable for a large group. Include brief descriptions, why it's a good fit, and perhaps a price indication (e.g., $, $$, $$$). Format the response using markdown.`;
         
         const responseText = await callGemini(prompt);
-        geminiResponseLeisure.innerHTML = marked.parse(responseText);
+        renderGeminiResponse(geminiResponseLeisure, responseText);
 
         geminiLoaderLeisure.style.display = 'none';
         geminiResponseLeisure.classList.remove('hidden');
@@ -475,7 +689,7 @@
         const prompt = `You are a Dubai travel and style expert. For Day ${day} of a trip in mid-November, suggest an appropriate and stylish outfit for a group of tourists. The day's activities are: "${activities}". Provide suggestions for both men and women, considering the weather (warm days, cooler evenings) and any cultural dress codes (especially for religious sites). Format the response using markdown with clear headings.`;
         
         const responseText = await callGemini(prompt);
-        geminiResponseWardrobe.innerHTML = marked.parse(responseText);
+        renderGeminiResponse(geminiResponseWardrobe, responseText);
 
         geminiLoaderWardrobe.style.display = 'none';
         geminiResponseWardrobe.classList.remove('hidden');
@@ -497,7 +711,7 @@
         const prompt = `You are a professional travel photographer. Provide 3-4 creative and practical photography tips for capturing stunning photos at "${location}" in the UAE. Include tips on composition, lighting (best time of day), and unique angles or subjects to focus on. Keep the advice concise and easy for amateur photographers to follow. Format the response using markdown.`;
         
         const responseText = await callGemini(prompt);
-        geminiResponsePhoto.innerHTML = marked.parse(responseText);
+        renderGeminiResponse(geminiResponsePhoto, responseText);
 
         geminiLoaderPhoto.style.display = 'none';
         geminiResponsePhoto.classList.remove('hidden');
@@ -509,7 +723,39 @@
     const modalContent = document.getElementById('modal-content');
     const modalClose = document.getElementById('modal-close');
     const modalLoader = document.getElementById('modal-loader');
-    
+
+    const apiKeyModal = document.getElementById('api-key-modal');
+    const apiKeyModalClose = document.getElementById('api-key-modal-close');
+    const configureApiKeyBtn = document.getElementById('configure-api-key-btn');
+    const cancelApiKeyBtn = document.getElementById('cancel-api-key-btn');
+    const saveApiKeyBtn = document.getElementById('save-api-key-btn');
+    const removeApiKeyBtn = document.getElementById('remove-api-key-btn');
+    const apiKeyInput = document.getElementById('api-key-input');
+    const apiKeyInputError = document.getElementById('api-key-input-error');
+
+    const closeApiKeyModal = () => {
+        if (!apiKeyModal) return;
+        apiKeyModal.style.display = 'none';
+        if (apiKeyInput) {
+            apiKeyInput.value = '';
+        }
+        if (apiKeyInputError) {
+            apiKeyInputError.classList.add('hidden');
+        }
+    };
+
+    const openApiKeyModal = () => {
+        if (!apiKeyModal) return;
+        apiKeyModal.style.display = 'flex';
+        if (apiKeyInput) {
+            apiKeyInput.value = apiKey || '';
+            apiKeyInput.focus();
+        }
+        if (apiKeyInputError) {
+            apiKeyInputError.classList.add('hidden');
+        }
+    };
+
     document.querySelectorAll('.insight-btn').forEach(button => {
         button.addEventListener('click', async () => {
             const topic = button.dataset.topic;
@@ -521,7 +767,7 @@
             const prompt = `You are a tour guide for a premium travel group in the UAE. Provide 3 fascinating and concise cultural or historical facts about "${topic}". The facts should be easy to understand for tourists. Format the response as a markdown bulleted list.`;
             
             const responseText = await callGemini(prompt);
-            modalContent.innerHTML = marked.parse(responseText);
+            renderGeminiResponse(modalContent, responseText);
             modalLoader.style.display = 'none';
         });
     });
@@ -535,6 +781,66 @@
             insightModal.style.display = 'none';
         }
     });
+
+    if (configureApiKeyBtn) {
+        configureApiKeyBtn.addEventListener('click', openApiKeyModal);
+    }
+
+    if (cancelApiKeyBtn) {
+        cancelApiKeyBtn.addEventListener('click', closeApiKeyModal);
+    }
+
+    if (apiKeyModalClose) {
+        apiKeyModalClose.addEventListener('click', closeApiKeyModal);
+    }
+
+    if (apiKeyModal) {
+        apiKeyModal.addEventListener('click', (event) => {
+            if (event.target === apiKeyModal) {
+                closeApiKeyModal();
+            }
+        });
+    }
+
+    if (saveApiKeyBtn) {
+        saveApiKeyBtn.addEventListener('click', () => {
+            if (!apiKeyInput) return;
+            const nextKey = apiKeyInput.value.trim();
+            if (!nextKey) {
+                if (apiKeyInputError) {
+                    apiKeyInputError.classList.remove('hidden');
+                }
+                return;
+            }
+            setApiKey(nextKey);
+            closeApiKeyModal();
+        });
+    }
+
+    if (removeApiKeyBtn) {
+        removeApiKeyBtn.addEventListener('click', () => {
+            setApiKey('');
+            closeApiKeyModal();
+        });
+    }
+
+    if (apiKeyInput) {
+        apiKeyInput.addEventListener('input', () => {
+            if (apiKeyInputError) {
+                apiKeyInputError.classList.add('hidden');
+            }
+        });
+        apiKeyInput.addEventListener('keydown', (event) => {
+            if (event.key === 'Enter') {
+                event.preventDefault();
+                if (saveApiKeyBtn) {
+                    saveApiKeyBtn.click();
+                }
+            }
+        });
+    }
+
+    updateApiKeyUi();
 
 </script>
 </body>


### PR DESCRIPTION
## Summary
- reset the API key modal error state whenever it opens so users start with a clean form
- add live validation feedback and allow pressing Enter to save the key without leaving the keyboard

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbc4b46dbc832191fc885fe9705afc